### PR TITLE
Fix incorrect directory references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The setup required can be broken into two types:
 
 ### Making Edits / Customizing the Template
 
-To setup, simply fork the repo and run `npm install` in order to get all the Gulp dev dependencies. Next, run `Gulp watch` to compile the Sass and minify the JavaScript. Alternatively, if you don't have Gulp installed globally, you can run the npm script `npm run watch`. Any changes done to the JavaScript (js/scripts.js) or Sass (sass/styles.scss) will be autocompiled and ready to go.
+To setup, simply fork the repo and run `npm install` in order to get all the Gulp dev dependencies. Next, run `gulp watch` to compile the Sass and minify the JavaScript. Alternatively, if you don't have Gulp installed globally, you can run the npm script `npm run watch`. Any changes done to the JavaScript (js/scripts.js) or Sass (scss/styles.scss) will be autocompiled and ready to go.
 
-All scripts are within `js/scripts.js` and get minified to `js/scripts.min.js`. All styles are in `sass/styles.scss` and get compiled to `css/styles.css`. Both the minified scripts file and compiled CSS file are what is loaded on the page by default.
+All scripts are within `js/scripts.js` and get minified to `js/scripts.min.js`. All styles are in `scss/styles.scss` and get compiled to `css/styles.css`. Both the minified scripts file and compiled CSS file are what is loaded on the page by default.
 
 At this point, the page is ready to go and you can begin to add your own information and make any needed changes. The sections below  contains a quick breakdown of each of the default sections and how they work.
 


### PR DESCRIPTION
## Summary
This PR fixes incorrect information in the README.md file that was causing confusion for users trying to follow the setup instructions.

## Changes Made
- **Fixed directory references**: Changed `sass/styles.scss` to `scss/styles.scss` in two locations to match the actual directory structure
- **Fixed command syntax**: Changed `Gulp watch` to `gulp watch` for correct lowercase command syntax

## Issues Fixed
1. **Line 50**: The README incorrectly referenced `sass/styles.scss` when the actual directory is `scss/`
2. **Line 52**: Another incorrect reference to `sass/styles.scss` 
3. **Line 50**: The command `Gulp watch` should be lowercase `gulp watch`

## Verification
- Confirmed that the actual directory structure uses `scss/` not `sass/`
- Verified that `gulpfile.js` watches `./scss/styles.scss`
- Checked that the `package.json` script uses `gulp watch`

These corrections ensure that users following the README instructions will reference the correct file paths and use the proper command syntax.

@ajohn40 can click here to [continue refining the PR](https://app.all-hands.dev/35a501b78d624c169168044c5be5b367)